### PR TITLE
Zap enhancement: Enable file download progress through config file option

### DIFF
--- a/etc/zap/zap_config.conf
+++ b/etc/zap/zap_config.conf
@@ -1,0 +1,2 @@
+# Enable the below option to see file download progress during package/overlay install
+#show_download_progress=yes

--- a/usr/lib/zap/copy-repo
+++ b/usr/lib/zap/copy-repo
@@ -6,6 +6,9 @@
 CURL=/usr/bin/curl
 WGET=/usr/bin/wget
 
+# For enabling progress bar for zap during file download
+confFile=/etc/zap/zap_config.conf
+SHOW_PROGRESS_DOWNLOAD="no"
 #
 # usage is
 #  repo destination
@@ -75,12 +78,31 @@ if [ ! -d "${DESTDIR}" ]; then
 fi
 
 #
-# grab the catalog and other metadata
+# grab the catalog and other metadata 
 #
-${CURL} -f -s -o ${DESTDIR}/catalog ${REPO}/catalog
-${CURL} -f -s -o ${DESTDIR}/aliases ${REPO}/aliases
-${CURL} -f -s -o ${DESTDIR}/index.html ${REPO}/index.html
-${CURL} -f -s -o ${DESTDIR}/filelist.bz2 ${REPO}/filelist.bz2
+while IFS='' read -r line || [[ -n "$line" ]]; 
+do
+case $line in
+   "show_download_progress=yes")
+    SHOW_PROGRESS_DOWNLOAD="yes"
+    ;;
+esac
+done<"$confFile" 
+
+case $SHOW_PROGRESS_DOWNLOAD in
+    "yes")
+     ${CURL} -f -o ${DESTDIR}/catalog ${REPO}/catalog
+     ${CURL} -f -o ${DESTDIR}/aliases ${REPO}/aliases
+     ${CURL} -f -o ${DESTDIR}/index.html ${REPO}/index.html
+     ${CURL} -f -o ${DESTDIR}/filelist.bz2 ${REPO}/filelist.bz2 
+    ;; 
+    *)
+     ${CURL} -f -s -o ${DESTDIR}/catalog ${REPO}/catalog
+     ${CURL} -f -s -o ${DESTDIR}/aliases ${REPO}/aliases
+     ${CURL} -f -s -o ${DESTDIR}/index.html ${REPO}/index.html
+     ${CURL} -f -s -o ${DESTDIR}/filelist.bz2 ${REPO}/filelist.bz2
+    ;;
+esac
 
 if [ ! -f ${DESTDIR}/catalog ]; then
    echo "ERROR: no catalog retrieved"
@@ -101,17 +123,39 @@ cat ${DESTDIR}/catalog | awk -F'|' '{print $1,$2,$4,$5}' | while read pkg ver fs
 do
     if [ ! -f "${DESTDIR}/${pkg}.${ver}.zap" ]; then
 	echo "Getting ${pkg}, $fsize bytes"
-	${CURL} -f -s -o ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+    case $SHOW_PROGRESS_DOWNLOAD in
+        *"yes")
+            ${CURL} -f -o ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+        ;;  
+        *)
+            ${CURL} -f -s -o ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+        ;;
+    esac
+    fi    
 	if [ -f "${DESTDIR}/${pkg}.${ver}.zap" ]; then
 	    rsize=`/usr/bin/stat -c '%s' ${DESTDIR}/${pkg}.${ver}.zap`
 	    if [ $rsize -eq $fsize ]; then
 		echo "Succesful download of ${pkg}.${ver}.zap"
 	    else
 		echo "ERROR: size mismatch for ${pkg}.${ver}.zap, retrying"
-		${WGET} -q -C -O ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+             case $SHOW_PROGRESS_DOWNLOAD in 
+                *"yes")
+                    ${WGET} -C -O ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+                ;;
+                *)
+                    ${WGET} -q -C -O ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+                ;;
+              esac
 	    fi
 	else
-	    ${WGET} -q -O ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+            case $SHOW_PROGRESS_DOWNLOAD in
+                *"yes")
+                    ${WGET} -O ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+                ;;
+                *)
+                    ${WGET} -q -O ${DESTDIR}/${pkg}.${ver}.zap ${REPO}/${pkg}.${ver}.zap
+                ;;
+            esac    
 	fi
     fi
     PKGMD5=`openssl md5 ${DESTDIR}/${pkg}.${ver}.zap| /usr/bin/awk '{print $NF}'`

--- a/usr/lib/zap/refresh-catalog
+++ b/usr/lib/zap/refresh-catalog
@@ -5,7 +5,8 @@
 
 ZAPLIBDIR="/usr/lib/zap"
 CFGDIR="/etc/zap"
-
+# For enabling progress bar for zap during file download
+confFile=/etc/zap/zap_config.conf
 #
 # global context switch
 # will force all configuration to be relative to the alternate root
@@ -25,11 +26,25 @@ case $1 in
 esac
 
 WCLIENT=/usr/bin/curl
-WARGS="-f -s -o"
-if [ ! -x $WCLIENT ]; then
-    WCLIENT=/usr/bin/wget
-    WARGS="-q -O"
-fi
+while IFS='' read -r line || [[ -n "$line" ]]; 
+do
+case $line in
+     "show_download_progress=yes")
+        WARGS="-f -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+             WARGS="-O"
+        fi
+      ;;  
+      *)
+        WARGS="-f -s -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+            WARGS="-q -O"
+        fi
+      ;;
+esac
+done<"$confFile"  
 
 refresh_repo() {
     frepo="$1"

--- a/usr/lib/zap/refresh-filelist
+++ b/usr/lib/zap/refresh-filelist
@@ -5,7 +5,8 @@
 
 ZAPLIBDIR="/usr/lib/zap"
 CFGDIR="/etc/zap"
-
+# For enabling progress bar for zap during file download
+confFile=/etc/zap/zap_config.conf
 #
 # global context switch
 # will force all configuration to be relative to the alternate root
@@ -25,11 +26,25 @@ case $1 in
 esac
 
 WCLIENT=/usr/bin/curl
-WARGS="-f -s -o"
-if [ ! -x $WCLIENT ]; then
-    WCLIENT=/usr/bin/wget
-    WARGS="-q -O"
-fi
+while IFS='' read -r line || [[ -n "$line" ]]; 
+do
+case $line in
+     "show_download_progress=yes")
+        WARGS="-f -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+            WARGS="-O"
+        fi
+      ;;
+     *)
+      WARGS="-f -s -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+            WARGS="-q -O"
+        fi
+       ;;
+esac
+done<"$confFile" 
 
 refresh_repo() {
     frepo="$1"

--- a/usr/lib/zap/refresh-overlays
+++ b/usr/lib/zap/refresh-overlays
@@ -6,7 +6,8 @@
 ZAPLIBDIR="/usr/lib/zap"
 CFGDIR="/etc/zap"
 ODIR="/var/sadm/overlays"
-
+# For enabling progress bar for zap during file download
+confFile=/etc/zap/zap_config.conf
 #
 # global context switch
 # will force all configuration to be relative to the alternate root
@@ -27,11 +28,25 @@ case $1 in
 esac
 
 WCLIENT=/usr/bin/curl
-WARGS="-f -s -o"
-if [ ! -x $WCLIENT ]; then
-    WCLIENT=/usr/bin/wget
-    WARGS="-q -O"
-fi
+while IFS='' read -r line || [[ -n "$line" ]]; 
+do
+case $line in
+     "show_download_progress=yes")
+        WARGS="-f -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+            WARGS="-O"
+        fi
+     ;;
+     *)
+              WARGS="-f -s -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+            WARGS="-q -O"
+        fi
+     ;;
+esac
+done<"$confFile"  
 
 refresh_repo() {
     frepo="$1"

--- a/usr/lib/zap/retrieve-image
+++ b/usr/lib/zap/retrieve-image
@@ -13,6 +13,8 @@
 
 ZAPLIBDIR="/usr/lib/zap"
 MODE="download"
+# For enabling progress bar for zap during file download
+confFile=/etc/zap/zap_config.conf
 #
 # checksum naming:
 # if it's saved as XXX.sha256 then it's a single checksum
@@ -51,11 +53,25 @@ if [ -n "$ZAP_PROXY" ]; then
 fi
 
 WCLIENT=/usr/bin/curl
-WARGS="-A ${USER_AGENT} -f -s -o"
-if [ ! -x $WCLIENT ]; then
-    WCLIENT=/usr/bin/wget
-    WARGS="-U ${USER_AGENT} -q -O"
-fi
+while IFS='' read -r line || [[ -n "$line" ]]; 
+do
+case $line in
+     "show_download_progress=yes")
+       WARGS="-A ${USER_AGENT} -f -o"
+    if [ ! -x $WCLIENT ]; then
+         WCLIENT=/usr/bin/wget
+        WARGS="-U ${USER_AGENT} -O"
+    fi
+    ;;
+    *)
+    WARGS="-A ${USER_AGENT} -f -s -o"
+    if [ ! -x $WCLIENT ]; then
+         WCLIENT=/usr/bin/wget
+        WARGS="-U ${USER_AGENT} -q -O"
+    fi
+    ;;
+esac
+done<"$confFile"
 
 #
 # we understand several schemes

--- a/usr/lib/zap/retrieve-pkg
+++ b/usr/lib/zap/retrieve-pkg
@@ -1,6 +1,8 @@
 #!/bin/ksh
 
 ZAPLIBDIR="/usr/lib/zap"
+# For enabling progress bar for zap during file download
+confFile=/etc/zap/zap_config.conf
 
 case $1 in
 -C)
@@ -31,11 +33,25 @@ if [ -n "$ZAP_PROXY" ]; then
 fi
 
 WCLIENT=/usr/bin/curl
-WARGS="-A ${USER_AGENT} -f -s -o"
-if [ ! -x $WCLIENT ]; then
-    WCLIENT=/usr/bin/wget
-    WARGS="-U ${USER_AGENT} -q -O"
-fi
+while IFS='' read -r line || [[ -n "$line" ]]; 
+do
+case $line in
+     "show_download_progress=yes")
+        WARGS="-A ${USER_AGENT} -f -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+            WARGS="-U ${USER_AGENT} -O"
+        fi
+      ;;
+     *)
+       WARGS="-A ${USER_AGENT} -f -s -o"
+       if [ ! -x $WCLIENT ]; then
+           WCLIENT=/usr/bin/wget
+           WARGS="-U ${USER_AGENT} -q -O"
+       fi
+      ;;
+esac
+done<"$confFile" 
 
 #
 # the verification here is mostly for debugging at this time

--- a/usr/lib/zap/upgrade
+++ b/usr/lib/zap/upgrade
@@ -13,7 +13,8 @@ BEADM="/sbin/beadm"
 ZFSCMD="/usr/sbin/zfs"
 DOIT=""
 ACTIVATE="false"
-
+# For enabling progress bar for zap during file download
+confFile=/etc/zap/zap_config.conf
 #
 # The general strategy here is:
 #  beadm create newver
@@ -146,11 +147,25 @@ do
 done
 
 WCLIENT=/usr/bin/curl
-WARGS="-f -s -o"
-if [ ! -x $WCLIENT ]; then
-    WCLIENT=/usr/bin/wget
-    WARGS="-q -O"
-fi
+while IFS='' read -r line || [[ -n "$line" ]]; 
+do
+case $line in
+     "show_download_progress=yes")
+        WARGS="-f -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+            WARGS="-O"
+        fi
+      ;;
+      *)
+        WARGS="-f -s -o"
+        if [ ! -x $WCLIENT ]; then
+            WCLIENT=/usr/bin/wget
+            WARGS="-q -O"
+        fi
+      ;;
+esac
+done<"$confFile"  
 
 NPKG=${NEWURL##*/}
 CACHE_DIR=`${ZAPLIBDIR}/zap-cfg cache-dir`

--- a/usr/share/zap/help.txt
+++ b/usr/share/zap/help.txt
@@ -4,6 +4,13 @@ ZAP
 The zap utility is the primary administration tool for software on
 Tribblix.
 
+By default, whenever operations such as install,update or refresh of overlay/packages and download of images during
+setup of zones are executed,zap fetches the needed files over the internet in silent mode,without showing progress of the 
+download. However the progress of the download process can be shown by enabling the following configuration option to
+/etc/zap/zap_config.conf:
+
+show_download_progress=yes 
+
 The basic usage is:
 
 zap subcommand [arguments ...]


### PR DESCRIPTION
By default zap,using curl or wget internally, fetches needed files during operations such as zone setup,package/overlay installation in silent mode. Due to this,end user does not know the progress of the file download operation. 

This PR enables the display of the file download progress if the user enables option "SHOW_DOWNLOAD_POGRESS=YES" in the new config file zap_config.conf ,  present in directory /etc/zap. 